### PR TITLE
Fix the typer so text doesn't change instantly

### DIFF
--- a/src/aristotle/babies.js
+++ b/src/aristotle/babies.js
@@ -1,41 +1,43 @@
-  var promo_strings = [
-    "build healthier communities.",
-    //"higher living standards.",
-    "reduce the cost of business.",
-    "build safer cities.",
-    "achieve gender equality.",
-    "build sustainable cities.",
-    "create a cleaner environment.",
-    "achieve positive outcomes.",
-    "do more!"
+let promo_strings = [
+  "build healthier communities.",
+  //"higher living standards.",
+  "reduce the cost of business.",
+  "build safer cities.",
+  "achieve gender equality.",
+  "build sustainable cities.",
+  "create a cleaner environment.",
+  "achieve positive outcomes.",
+  "do more!"
+];
+let shuffle = true;
+
+if (window.location.hash == "#derek") {
+  promo_strings = [
+    "teach Kids Who Can't Read Good and Who Wanna Learn to Do Other Stuff Good Too."
   ];
-var shuffle = true;
-  if (window.location.hash == "#derek") {
-      promo_strings = [
-        "teach Kids Who Can't Read Good and Who Wanna Learn to Do Other Stuff Good Too."
-      ];
-  } else if (window.location.hash == "#rufus") {
-    promo_strings = [
-      "get cleaner air.",
-      "get cleaner water.",
-      "get cleaner dirt.",
-      "get higher bowling averages.",
-      "get lower mini-golf scores.",
-      "get more excellent water-slides.", 
-      "have most excellent adventures.",
-      "have a better San Dimas.",
-    ];
-    shuffle = false;
-  }
-      
+} else if (window.location.hash == "#rufus") {
+  promo_strings = [
+    "get cleaner air.",
+    "get cleaner water.",
+    "get cleaner dirt.",
+    "get higher bowling averages.",
+    "get lower mini-golf scores.",
+    "get more excellent water-slides.", 
+    "have most excellent adventures.",
+    "have a better San Dimas.",
+  ];
+  shuffle = false;
+}
+
 $(document).ready(function() {
-  var typed = new Typed(".healthy-babies span", {
+
+  let typed = new Typed('.healthy-babies > span', {
     strings: promo_strings,
-    startDelay: 2000,
     typeSpeed: 40,
     loop: true,
     showCursor: true,
     backDelay: 2000,
+    smartBackspace: false,
     backSpeed: 20,
     shuffle: shuffle,
     cursorChar: "|",

--- a/src/index.html
+++ b/src/index.html
@@ -26,8 +26,9 @@ og:
                 <h1 class="site-headline {% if page.dark %}text-white{% endif %}">
                     Get more out of your data.
                 </h1>
-                <h2 class="mb-5 {% if page.dark %}text-white{% endif %}">So you can 
-                    <span class="healthy-babies"><span>achieve positive outcomes.</span></span>
+                <h2 class="mb-5 {% if page.dark %}text-white{% endif %}">
+                    So you can
+                    <span class="healthy-babies"><span></span></span>
                 </h2>
             </div>
             <div class="row">


### PR DESCRIPTION
This was due to it showing original text of the span, plus some issues
with smartBackspace.

Had to clear the initial text out unfortunately. It could instead be cleared out with another script
that is loaded earlier if we want to keep that initial text for non js users or crawlers.
